### PR TITLE
Adjust Reform Printing

### DIFF
--- a/reform.py
+++ b/reform.py
@@ -8,10 +8,10 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 try:
     import pgzip as gzip_module
-    print("Using pgzip for gzip operations.")
+    print("\nUsing pgzip for gzip operations.\n")
 except ImportError:
     import gzip as gzip_module
-    print("pgzip not found, falling back to gzip.")
+    print("\npgzip not found, falling back to gzip.\n")
 
 
 def main():
@@ -33,14 +33,26 @@ def main():
 		print("-------------------------------------------")
   		## Read the new fasta (to be inserted into the ref genome)
 		try:
+			filename_fa = in_arg.in_fasta[index]
+			if not os.path.exists(filename_fa):
+				raise FileNotFoundError(f"Error: File {filename_fa} does not exist.")
+			real_path_fa = os.path.realpath(filename_fa)
 			record = list(SeqIO.parse(in_arg.in_fasta[index], "fasta"))[0]
 		except IndexError:
-			filename = in_arg.in_fasta[index].name
-			raise ValueError(f"Error: {filename} is not a valid FASTA file.")
+			raise ValueError(f"Error: {filename_fa} is not a valid FASTA file.")
 		except Exception as e:
 			raise ValueError(f"Error parsing FASTA file: {str(e)}")
+		print("Preparing to create new FASTA file")
+		print(f"Original FASTA: {real_path_fa}")
+		filename_gff = in_arg.in_gff[index]
+		if not os.path.exists(filename_gff):
+			raise FileNotFoundError(f"Error: File {filename_gff} does not exist.")
+		real_path_gff = os.path.realpath(filename_gff)
+		print("Preparing to create new annotation file")
+		print(f"Original Annotation: {real_path_gff}")
+		print() ### print new line
 
-		## Generate index of sequences from ref reference fasta
+  		## Generate index of sequences from ref reference fasta
 		if prev_fasta_path:
 			chrom_seqs = index_fasta(prev_fasta_path)
 			os.remove(prev_fasta_path)
@@ -95,11 +107,6 @@ def main():
 					SeqIO.write([new_record], f, "fasta")
 				else:
 					SeqIO.write([chrom_seqs[s]], f, "fasta")
-		if (index == iterations-1):
-			print("------------------------------------------")
-			print("Reform Complete")
-			print("------------------------------------------")
-			print("New fasta file created: ", new_fasta)
 		
 		## Read in new GFF features from in_gff
 		in_gff_lines = get_in_gff_lines(in_arg.in_gff[index])
@@ -123,8 +130,11 @@ def main():
 				new_gff_path = create_new_gff(new_gff_name, in_arg.ref_gff, in_gff_lines, position, down_position, seq.id, len(str(record.seq)))
 		prev_gff_path = new_gff_path
 		if (index == iterations-1):
-			print(f"New fasta file created: {new_gff_path}")
-			print(f"Original Annotation: {in_arg.ref_gff}")
+			print("------------------------------------------")
+			print("Reform Complete")
+			print("------------------------------------------")
+			print(f"New .fa file created:  {os.path.realpath(new_fasta)}")
+			print(f"New {annotation_ext} file created: {os.path.realpath(new_gff_path)}")
 
 
 def index_fasta(fasta_path):

--- a/reform.py
+++ b/reform.py
@@ -27,7 +27,11 @@ def main():
 
 	## Sequential processing
 	for index in range(iterations):
-		## Read the new fasta (to be inserted into the ref genome)
+		# Start interation
+		print("-------------------------------------------")
+		print(f"Begin modification from in{index+1}.fa")
+		print("-------------------------------------------")
+  		## Read the new fasta (to be inserted into the ref genome)
 		try:
 			record = list(SeqIO.parse(in_arg.in_fasta[index], "fasta"))[0]
 		except IndexError:
@@ -91,16 +95,17 @@ def main():
 					SeqIO.write([new_record], f, "fasta")
 				else:
 					SeqIO.write([chrom_seqs[s]], f, "fasta")
-		print("New fasta file created: ", new_fasta)
-		
-		print("Preparing to create new annotation file")
+		if (index == iterations-1):
+			print("------------------------------------------")
+			print("Reform Complete")
+			print("------------------------------------------")
+			print("New fasta file created: ", new_fasta)
 		
 		## Read in new GFF features from in_gff
 		in_gff_lines = get_in_gff_lines(in_arg.in_gff[index])
 		
 		## Create a temp file for gff, if index is not equal to last iteration
 		annotation_name, annotation_ext = get_ref_basename(in_arg.ref_gff)
-		print(in_arg.ref_gff)
 		if index < iterations - 1:
 			temp_gff = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix=annotation_ext)
 			temp_gff_name = temp_gff.name
@@ -117,7 +122,9 @@ def main():
 			else:
 				new_gff_path = create_new_gff(new_gff_name, in_arg.ref_gff, in_gff_lines, position, down_position, seq.id, len(str(record.seq)))
 		prev_gff_path = new_gff_path
-		print("New {} file created: {} ".format(annotation_ext.upper(), prev_gff_path))
+		if (index == iterations-1):
+			print(f"New fasta file created: {new_gff_path}")
+			print(f"Original Annotation: {in_arg.ref_gff}")
 
 
 def index_fasta(fasta_path):
@@ -394,6 +401,7 @@ def create_new_gff(new_gff_name, ref_gff, in_gff_lines, position, down_position,
 					# and ends after down_position
 					elif gff_feat_start <= position and gff_feat_end > down_position:
 						print("Feature split")
+						print(line)
 						# Which side of the feature depends on the strand (we add this as a comment)
 						(x, y) = ("5", "3") if gff_feat_strand == "+" else ("3", "5")
 						


### PR DESCRIPTION
1. Indicate the start of each modification round and confirm when the reform process is complete.;
2. During each modification, print the realpath of the original FASTA and annotation files;
3. After reform process, display the realpath of the newly generated .fa and .gtf/.gff files;
4. Specify whether gzip or pgzip is being used;